### PR TITLE
docs: configura Claude Code e fluxo de imagens via imghost

### DIFF
--- a/.claude/rules/imagens-via-imghost.md
+++ b/.claude/rules/imagens-via-imghost.md
@@ -1,0 +1,47 @@
+# Imagens dos e-mails: sempre via skill `imghost`
+
+Toda imagem que for parar num `.mjml` precisa ser **hospedada remotamente antes**
+de ser referenciada. O upload é feito **exclusivamente** pela skill `imghost`.
+
+## Regra
+
+1. Recebeu uma imagem (arquivo local, print, ou URL de terceiro) para usar num
+   e-mail → suba pela skill `imghost` primeiro.
+2. Use a URL pública devolvida pela skill no `<mj-image src="...">`.
+3. **Nunca** copie o arquivo para dentro do repositório. Nada de `assets/`,
+   `src/**/img/`, nem binário commitado — o repo versiona só `.mjml`.
+4. Nunca embuta a imagem em base64 (`data:` URI): clientes de e-mail cortam ou
+   bloqueiam, e o HTML colado na ferramenta de disparo fica gigante.
+5. Nunca linke direto o host de terceiro (Canva, Drive, WhatsApp, CDN de banco
+   de imagem). Esses links expiram ou têm hotlink bloqueado e o e-mail quebra
+   na caixa de entrada do lead. Espelhe com `imghost from-url` e use a cópia.
+
+## Como chamar
+
+O binário **não está no `PATH`**. Invoque pelo caminho do repo:
+
+```bash
+.claude/skills/imghost/bin/imghost upload    caminho/da/imagem.png   # imprime só a URL
+.claude/skills/imghost/bin/imghost from-url  https://host/externo.png  # espelha remoto
+.claude/skills/imghost/bin/imghost delete    https://imghost.saneducacional.com.br/xxxxx.png
+```
+
+Detalhes de flags, limites e config estão em `.claude/skills/imghost/SKILL.md`.
+
+## Cuidados específicos de e-mail
+
+- **Guarde a URL.** O host não tem endpoint de listagem — a URL devolvida é o
+  único handle que existe. Sempre mostre ela ao usuário depois do upload.
+- **Resize:** só `100 200 400 800 1200 1600` são aceitos (`?w=N`); qualquer
+  outro valor devolve HTTP 400. O corpo do e-mail tem `602px`, então `?w=1200`
+  é o alvo normal para ficar nítido em tela retina.
+- **Sem dedupe:** subir o mesmo arquivo duas vezes gera dois nomes diferentes.
+  Reaproveite a URL já existente em vez de re-subir.
+- Mantenha `fluid-on-mobile="true"` no `mj-image`, como no resto do repo.
+
+## Legado
+
+E-mails antigos apontam para `https://assets.saneducacional.com.br/emails/<campanha>/...`,
+um bucket publicado à parte. **Não mexa nessas URLs** e não tente subir nada
+para lá — não há fluxo automatizado para esse bucket. Imagem nova vai para o
+`imghost`.

--- a/.claude/skills/imghost/.env.example
+++ b/.claude/skills/imghost/.env.example
@@ -1,0 +1,2 @@
+IMGHOST_URL=https://imghost.saneducacional.com.br
+IMGHOST_KEY=coloque-aqui-a-chave-do-imgpush

--- a/.claude/skills/imghost/SKILL.md
+++ b/.claude/skills/imghost/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: imghost
+description: Use when the user asks to upload, host, share, or embed a local image (PNG / JPEG / GIF / WebP) on their private image host at imghost.saneducacional.com.br. Returns the public URL and can format it as ready-to-paste Markdown or HTML for docs, READMEs, or chat. Also uploads by remote URL and deletes prior uploads.
+---
+
+# imghost
+
+Wraps the operator's private imgpush instance behind a single `imghost` CLI on
+`PATH`. Always shell out to the CLI; never craft the HTTP request by hand and
+never echo the bearer token.
+
+## When to invoke
+
+- The user wants a shareable URL for a local image ("sobe essa imagem", "hospeda
+  esse print", "upload this png")
+- Markdown to drop into a `.md` (`![alt](url)`)
+- An `<img>` tag for a page
+- Mirroring a remote image onto their own host
+- Deleting something they uploaded before
+
+If the user pastes an image inline without naming a file, ask for the path —
+the CLI uploads from disk (or stdin).
+
+## CLI cheat sheet
+
+| Goal | Command |
+|---|---|
+| Public URL only | `imghost upload PATH` |
+| Markdown tag | `imghost md PATH` |
+| HTML `<img>` | `imghost html PATH` |
+| Raw JSON response | `imghost upload --json PATH` |
+| Mirror a remote image | `imghost from-url https://…` |
+| Delete | `imghost delete FILENAME` (or paste the full URL) |
+| Check config + host health | `imghost whoami` |
+
+`--alt "..."` overrides alt text on `md`/`html` (defaults to the filename).
+`--w N` / `--h N` append a resize query to the returned URL.
+`PATH` may be `-` to read bytes from stdin.
+
+## Typical flows
+
+### Screenshot into a markdown doc
+
+```bash
+imghost md ~/prints/dashboard.png
+# ![dashboard.png](https://imghost.saneducacional.com.br/k3f9a.png)
+```
+
+Paste the line as-is.
+
+### Thumbnail-sized embed
+
+```bash
+imghost md ~/prints/wide.png --w 400 --alt "visão geral"
+# ![visão geral](https://imghost.saneducacional.com.br/p2mza.png?w=400)
+```
+
+### Clean up
+
+```bash
+imghost delete https://imghost.saneducacional.com.br/k3f9a.png
+# {"status":"deleted","cached_files_removed":"2"}
+```
+
+## Constraints that will bite
+
+- **Only these resize values work:** `100 200 400 800 1200 1600`. Anything else
+  returns HTTP 400 — the whitelist exists so nobody can force arbitrary resizes.
+- **Max 20 MB** per file.
+- **There is no listing endpoint.** The host has no database; you cannot
+  enumerate past uploads. If a link is lost, the file is only findable by
+  browsing `/home/self-hosted/imgpush/images/` on the server. So: after an
+  upload, always surface the URL to the user — it is the only handle that exists.
+- Uploads are not deduped by content; uploading the same file twice yields two
+  distinct filenames.
+
+## Output contract
+
+- `upload` and `from-url` print **only** the URL on stdout — pipe them directly.
+- `md` / `html` print exactly one line.
+- `delete` prints the raw JSON. Errors go to stderr with a non-zero exit
+  (`curl --fail-with-body` is on, so 4xx bodies still surface).
+
+## Don't
+
+- Don't print `.env` contents or the bearer token in user-visible output.
+- Don't cat binary image bytes to the terminal — pass paths to the CLI.
+- Don't hand-roll the curl call; the CLI owns auth and URL construction.
+
+## Config
+
+`IMGHOST_URL` and `IMGHOST_KEY` resolve from the first source that has them:
+process env → `$IMGHOST_ENV` → `<skill-dir>/.env` → `~/.config/imghost/.env`.

--- a/.claude/skills/imghost/bin/imghost
+++ b/.claude/skills/imghost/bin/imghost
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Thin CLI over the imgpush instance. Auth + URL building live here so callers
+# (and agents) never handle the bearer token.
+set -euo pipefail
+
+# Resolve through the PATH symlink so .env is found in the skill dir, not ~/.local.
+SELF="${BASH_SOURCE[0]}"
+SELF="$(readlink -f "$SELF" 2>/dev/null || printf '%s' "$SELF")"
+SELF_DIR="$(cd "$(dirname "$SELF")/.." && pwd)"
+
+# Config precedence: process env > $IMGHOST_ENV > skill-local .env > XDG.
+load_env() {
+  [[ -n "${IMGHOST_URL:-}" && -n "${IMGHOST_KEY:-}" ]] && return 0
+  local f
+  for f in "${IMGHOST_ENV:-}" "$SELF_DIR/.env" \
+           "${XDG_CONFIG_HOME:-$HOME/.config}/imghost/.env"; do
+    [[ -n "$f" && -f "$f" ]] || continue
+    # shellcheck disable=SC1090
+    set -a; source "$f"; set +a
+    break
+  done
+}
+
+die() { printf 'imghost: %s\n' "$*" >&2; exit 1; }
+
+require_config() {
+  load_env
+  [[ -n "${IMGHOST_URL:-}" ]] || die "IMGHOST_URL not set (see $SELF_DIR/.env.example)"
+  [[ -n "${IMGHOST_KEY:-}" ]] || die "IMGHOST_KEY not set (see $SELF_DIR/.env.example)"
+  IMGHOST_URL="${IMGHOST_URL%/}"
+}
+
+# imgpush answers uploads with {"filename":"abc12.png"} and nothing else.
+extract_filename() {
+  sed -n 's/.*"filename"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
+
+# Accepts a bare filename or a full URL; always yields the bare filename.
+basename_of() { printf '%s\n' "${1##*/}" | cut -d'?' -f1; }
+
+usage() {
+  cat <<'EOF'
+imghost — upload images to the private imgpush host
+
+  imghost upload PATH [--json] [--w N] [--h N]
+  imghost md     PATH [--alt TEXT] [--w N] [--h N]
+  imghost html   PATH [--alt TEXT] [--w N] [--h N]
+  imghost from-url URL [--json]
+  imghost delete FILENAME|URL
+  imghost whoami
+
+PATH may be "-" to read image bytes from stdin.
+Valid --w / --h values: 100 200 400 800 1200 1600 (server-enforced).
+EOF
+}
+
+# --- arg parsing ---------------------------------------------------------
+cmd="${1:-}"; shift || true
+[[ -z "$cmd" || "$cmd" == "-h" || "$cmd" == "--help" ]] && { usage; exit 0; }
+
+ALT="" JSON=0 W="" H="" POS=()
+while (($#)); do
+  case "$1" in
+    --alt)  ALT="${2:?--alt needs a value}"; shift 2 ;;
+    --w)    W="${2:?--w needs a value}";     shift 2 ;;
+    --h)    H="${2:?--h needs a value}";     shift 2 ;;
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; POS+=("$@"); break ;;
+    *)  POS+=("$1"); shift ;;
+  esac
+done
+
+query() {
+  local q=""
+  [[ -n "$W" ]] && q="w=$W"
+  [[ -n "$H" ]] && q="${q:+$q&}h=$H"
+  printf '%s' "${q:+?$q}"
+}
+
+TMPFILE=""
+# The trap fires in top-level scope, so the path it reads must not be `local`.
+cleanup() { [[ -n "${TMPFILE:-}" ]] && rm -f "$TMPFILE"; return 0; }
+trap cleanup EXIT
+
+do_upload() {
+  local path="$1" src
+  [[ -n "$path" ]] || die "missing PATH"
+  if [[ "$path" == "-" ]]; then
+    TMPFILE="$(mktemp "${TMPDIR:-/tmp}/imghost.XXXXXX")"
+    cat > "$TMPFILE"
+    src="$TMPFILE"
+  else
+    [[ -f "$path" ]] || die "no such file: $path"
+    src="$path"
+  fi
+
+  local resp
+  resp="$(curl --fail-with-body -sS \
+            -F "file=@$src" \
+            -H "Authorization: Bearer $IMGHOST_KEY" \
+            "$IMGHOST_URL/")" || die "upload failed: $resp"
+
+  if ((JSON)); then printf '%s\n' "$resp"; return; fi
+
+  local fn; fn="$(printf '%s' "$resp" | extract_filename)"
+  [[ -n "$fn" ]] || die "unexpected response: $resp"
+  printf '%s/%s%s\n' "$IMGHOST_URL" "$fn" "$(query)"
+}
+
+case "$cmd" in
+  upload)
+    require_config
+    do_upload "${POS[0]:-}"
+    ;;
+
+  md|html)
+    require_config
+    path="${POS[0]:-}"
+    url="$(do_upload "$path")"
+    alt="$ALT"
+    [[ -z "$alt" ]] && { [[ "$path" == "-" ]] && alt="image" || alt="$(basename_of "$path")"; }
+    if [[ "$cmd" == "md" ]]; then
+      printf '![%s](%s)\n' "$alt" "$url"
+    else
+      printf '<img src="%s" alt="%s" />\n' "$url" "$alt"
+    fi
+    ;;
+
+  from-url)
+    require_config
+    src="${POS[0]:-}"; [[ -n "$src" ]] || die "missing URL"
+    resp="$(curl --fail-with-body -sS \
+              -X POST -H 'Content-Type: application/json' \
+              -H "Authorization: Bearer $IMGHOST_KEY" \
+              -d "{\"url\":\"$src\"}" \
+              "$IMGHOST_URL/")" || die "upload failed: $resp"
+    if ((JSON)); then printf '%s\n' "$resp"; exit 0; fi
+    fn="$(printf '%s' "$resp" | extract_filename)"
+    [[ -n "$fn" ]] || die "unexpected response: $resp"
+    printf '%s/%s%s\n' "$IMGHOST_URL" "$fn" "$(query)"
+    ;;
+
+  delete)
+    require_config
+    target="${POS[0]:-}"; [[ -n "$target" ]] || die "missing FILENAME|URL"
+    curl --fail-with-body -sS -X DELETE \
+      -H "Authorization: Bearer $IMGHOST_KEY" \
+      "$IMGHOST_URL/$(basename_of "$target")"
+    echo
+    ;;
+
+  whoami)
+    require_config
+    printf 'url: %s\nkey: %s…%s (%d chars)\n' \
+      "$IMGHOST_URL" "${IMGHOST_KEY:0:4}" "${IMGHOST_KEY: -4}" "${#IMGHOST_KEY}"
+    curl --fail-with-body -sS "$IMGHOST_URL/liveness"; echo
+    ;;
+
+  *) die "unknown command: $cmd (try --help)" ;;
+esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## O que é este repositório
+
+Templates de e-mail marketing da **San Educacional**, escritos em [MJML](https://documentation.mjml.io/) e compilados para HTML. Não há aplicação, testes ou lint — o "código" são os arquivos `.mjml` em `src/`, e o único build converte MJML → HTML em `dist/`. O HTML gerado é colado na ferramenta de disparo; `dist/` é gitignorado (exceto `.gitkeep`).
+
+Conteúdo dos e-mails é em **português brasileiro**.
+
+## Comandos
+
+```bash
+bun install         # instala dependências
+bun run watch       # compila src/**/*.mjml → dist/ ao salvar + servidor em http://localhost:3000 (listagem de diretórios)
+bun run build       # compila tudo uma vez
+bun run clean       # apaga e recria dist/
+```
+
+`bun run watch` é o fluxo normal de desenvolvimento: o servidor expõe `dist/` também no IP da rede local, para abrir o e-mail no celular e conferir a versão mobile. Não existe suíte de testes; validação = compilar sem warnings do MJML (`scripts/mjml-build.mjs` imprime `[mjml] N issue(s)`) e inspecionar o HTML no navegador.
+
+## Estrutura
+
+`src/campanhas/<campanha>/<arquivo>.mjml` → `dist/campanhas/<campanha>/<arquivo>.html`. O build espelha a árvore de `src/` (`scripts/mjml-build.mjs`), então a pasta define a organização por campanha:
+
+- `tecnico-para-tecnologo/` — um e-mail avulso por curso (agronegocio, edificacoes, eletrotecnica, estetica, ...)
+- `<curso>-sequencia/` — sequências numeradas (`sequenciaedificacoes1..5`, `sequenciasecretariado1..6`, `sequenciatransacoes1..4`); cada arquivo é um e-mail de um fluxo, e o texto de um faz gancho com o próximo ("No próximo e-mail, vamos...")
+
+Cada `.mjml` é **autocontido** (300–400 linhas): não há `mj-include`, partials nem componentes compartilhados. Ao criar um novo e-mail, copie o arquivo mais próximo da mesma sequência/campanha e edite — é o padrão estabelecido em todo o histórico do repo.
+
+## Convenções obrigatórias dos templates
+
+**Variáveis de merge da plataforma de disparo** (sintaxe Smarty-like, deixe literal no MJML):
+
+- `{$codlead}` — id do lead, sempre presente na querystring dos links de redirect
+- `{$name|default('Estudante')}` — saudação; sempre com `default`, nunca `{$name}` sozinho
+- `{$unsubscribe}` — href do link "Descadastre-se" no rodapé
+
+**Links de CTA** nunca apontam para o destino final; passam pelo redirect de rastreio:
+
+```
+https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=14&amp;fornecedor=07&amp;curso=000&amp;nome_produto=...&amp;nome_curso=...
+```
+
+Use `&amp;` (não `&`) dentro dos atributos `href`. Os pares `produto`/`fornecedor`/`curso` identificam a campanha — copie-os do e-mail vizinho da mesma sequência em vez de inventar; errar isso quebra o rastreamento e já motivou vários commits de correção.
+
+**Imagens** são todas remotas — nunca há binário no repo (a pasta local `assets/` está vazia). E-mails antigos apontam para `https://assets.saneducacional.com.br/emails/<campanha>/...`, um bucket publicado à parte sem fluxo automatizado; mantenha essas URLs como estão. **Imagem nova sobe pela skill `imghost`** — ver @.claude/rules/imagens-via-imghost.md.
+
+**Layout**: `<mj-body width="602px">` com todo o conteúdo dentro de um `<mj-wrapper padding="0px">`; `mj-head` traz a fonte Poppins do Google Fonts e um `mj-attributes` com defaults de `mj-text`/`mj-button`. Rodapé fixo: bloco de CTA final + assinatura "Atenciosamente, Equipe San Educacional" + divisor + link de descadastro.
+
+**Responsividade**: clientes de e-mail não suportam flex/grid. O padrão do repo é `mj-section`/`mj-column` com `css-class` (`card-section`, `card-item`, `card-centered`, `salary-card`, `cargo-box`) e um bloco `<mj-style>` com `@media only screen and (max-width: 480px)` que força `width: 100% !important; display: block !important` nesses elementos. Use `fluid-on-mobile="true"` em `mj-image`. Sempre valide o mobile — grande parte dos commits `fix:` do repo é responsividade.
+
+## Git
+
+Commits em português, no padrão `feat: adiciona email N da sequência de <curso>` / `fix: corrige ...`. Trabalho feito em branches `feat/sequencia-<curso>` e integrado à `main` via PR no repositório `San-Educacional/emails-sanead`.


### PR DESCRIPTION
## O que muda

Adiciona a configuração de projeto do Claude Code. Nenhum template `.mjml` foi tocado — o build e os e-mails existentes seguem idênticos.

## Commits

1. **`chore:` skill `imghost`** — CLI que encapsula a instância privada de imgpush. Sobe imagem local (`upload`), espelha imagem remota (`from-url`) e devolve a URL pública pronta para o `<mj-image src>`. O token fica só no `.env` local, que é gitignorado; o `.env.example` vai com placeholder.
2. **`docs:` regra de imagens** — `.claude/rules/imagens-via-imghost.md`. Imagem nova de e-mail passa obrigatoriamente pela skill antes de ser referenciada. Proíbe binário no repo, `data:` URI e link direto para host de terceiro (Canva, Drive), que expira ou bloqueia hotlink e quebra o e-mail na caixa do lead.
3. **`docs:` `CLAUDE.md`** — guia do repositório: build MJML, estrutura por campanha e convenções obrigatórias dos templates (variáveis de merge, redirect de rastreio, layout, responsividade).

## Notas para o review

- O bucket legado `assets.saneducacional.com.br` continua intocado — a regra vale só para imagem nova.
- O binário `imghost` não está no `PATH`; a regra documenta a chamada pelo caminho do repo.
- O host não tem endpoint de listagem: a URL devolvida no upload é o único handle do arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)