### PR TITLE
feat: sequência R4 — Licenciatura Plena (6 e-mails)

### DIFF
--- a/.claude/skills/figma-para-mjml/SKILL.md
+++ b/.claude/skills/figma-para-mjml/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: figma-para-mjml
+description: Use when implementing an email design from Figma as MJML in this repo — "implement this design from Figma", a figma.com/design URL, "cria a sequência X a partir do Figma", "monta esse e-mail do Figma". Covers the multi-agent pipeline (Opus extrai o design, Sonnet implementa, Opus revisa), the MJML adaptations that make a designer's mockup survive a real email client, and the visual QA loop with screenshots. Also read it before touching any media query in a .mjml deste repo.
+---
+
+# figma-para-mjml
+
+Traduz um design do Figma para um `.mjml` deste repo. O design **sempre** vem
+com coisas que não existem em cliente de e-mail; metade do trabalho é decidir o
+que vira pixel, o que vira cor sólida e o que é descartado.
+
+Leia junto: `CLAUDE.md` e `.claude/rules/imagens-via-imghost.md`.
+
+## Pipeline com subagentes
+
+Vale a pena quando são vários e-mails de uma sequência. Por e-mail, duas
+equipes-de-um em série:
+
+1. **Lead (Opus)** — navega o Figma, baixa e otimiza os JPEG, sobe no `imghost`,
+   escreve uma spec em markdown no scratchpad. **Não escreve o `.mjml`.**
+2. **Implementador (Sonnet)** — lê só a spec + um `.mjml` já aprovado da mesma
+   sequência, escreve o arquivo, roda `bun run build` até zerar warning.
+   **Não abre o Figma MCP** — não precisa, e economiza contexto.
+3. **Lead (Opus) de novo**, via `SendMessage` no mesmo agente — revisa a
+   implementação contra a spec e o design, e corrige ele mesmo o arquivo. O
+   contexto do design já está na cabeça dele; respawnar joga isso fora.
+4. **Orquestrador** — a conferência visual é sua e centralizada. Proíba os
+   subagentes de abrir navegador, senão a RAM vai embora.
+
+**Por que Opus na extração:** o Figma MCP devolve muito token e exige decidir o
+que é essencial. Sonnet implementa bem a partir de uma spec pronta, mas se
+afoga navegando o design.
+
+**Escreva um `PADRAO.md` no scratchpad antes de soltar qualquer equipe** e mande
+todo mundo obedecê-lo acima da própria spec. É onde entram paleta, escala
+tipográfica, href de CTA e as receitas abaixo. Quando descobrir uma armadilha
+nova, promova pro `PADRAO.md` na hora — as equipes seguintes já nascem imunes.
+Segurar a primeira leva (3 de 6) até ela voltar pega erro de instrução antes de
+replicá-lo.
+
+## Seletores de media query — a armadilha que não aparece no build
+
+Compila limpo, parece certo no código, e **não faz absolutamente nada**. Já
+derrubou 3 e-mails; três equipes independentes chegaram na mesma causa.
+
+| alvo | errado (silenciosamente inócuo) | certo |
+|---|---|---|
+| texto de `mj-text` | `.classe { font-size }` | `.classe div { font-size: … !important }` |
+| padding de `mj-section` | `.classe > tbody > tr > td` | `.classe > table > tbody > tr > td` |
+| botão `mj-button` | `.classe { width: 100% }` | `.classe table { width: 100% !important }` **+** `.classe a { display: block !important; width: auto !important }` |
+
+Por quê: `css-class` em `mj-text` cai no `<td>`, e o MJML força `font-size:0px`
+nesse `<td>` — o valor real está inline no `<div>` interno. `css-class` em
+`mj-section` cai no `<div>` externo, cujo filho é `<table>`, não `<tbody>`. E
+`mj-button` vira `<table width:NNN>` + `<a width:MMM>` dentro do td.
+
+⚠️ **O padrão inválido `.classe > tbody > tr > td` está espalhado pelos e-mails
+antigos do repo** (veio do `sequenciasecretariado1.mjml`). Se for mexer num
+template legado, confira se a media query dele está viva antes de confiar nela.
+
+Ao mirar `.classe div`, cuidado com `<div>` aninhado (caixa com fundo + texto
+dentro): o seletor pega os dois níveis. Ponha uma classe no `<div>` certo em vez
+de contar níveis.
+
+## Critérios de aceite
+
+```bash
+bun run build 2>&1 | grep -i 'issue\|warn\|error'   # tem que sair vazio
+node bin/overflow.mjs dist/.../arquivo.html 375     # scrollWidth == 375
+```
+
+Um único `width` fixo maior que a tela empurra o corpo inteiro e o e-mail chega
+torto no celular. Causas já vistas: botão de CTA com texto longo; `border: 1px`
+em duas colunas de um `mj-group` (2px × 2 = 4px de estouro).
+
+## Adaptações que sempre aparecem
+
+| no design | no e-mail |
+|---|---|
+| degradê sobre foto | componha foto + overlay num único JPEG antes de subir |
+| degradê de fundo | cor sólida |
+| `rgba()` | achate para hex, calculado sobre a cor de fundo real |
+| `box-shadow` / glow | `border: 1px solid` ou nada |
+| texto sobre foto | tire o texto da imagem: foto + faixa de cor sólida com `mj-text` |
+| elemento em `position:absolute` (pílula, badge) | vira faixa própria acima/abaixo, ou `<span>` com `border-radius:999px` |
+| linha conectando itens de timeline | descarte — atravessa fronteira de `mj-section`; a copy sustenta a leitura |
+| bolinha/ícone colorido | `<div>` com `background-color` + `border-radius:999px` dentro de `mj-text` (Outlook mostra quadrado; melhor que sumir com imagem bloqueada) |
+| `text-transform: uppercase` | escreva em caixa alta direto no MJML |
+| ícone vetorial simples | recrie com emoji/cor; não suba imagem |
+
+**Truque do hero full-bleed:** force as últimas linhas de pixel do JPEG para a
+mesma cor da seção seguinte. Aí o hero vai sem `border-radius` e sem padding
+lateral, encostando nas bordas, e a emenda desaparece. Qualquer margem quebra o
+efeito.
+
+**`mj-section` não aninha.** Caixa dentro de card = `<div style="background-color:…;border-radius:…">`
+dentro de `mj-text`. Card longo = várias `mj-section` consecutivas de mesmo
+fundo, com raio só no topo da primeira e na base da última.
+
+**Fundo: cada seção declara o seu.** Não deixe seção herdar do `mj-body` — o
+`background-color` do body pinta o canvas inteiro, inclusive as calhas laterais
+no desktop e a sobra abaixo do conteúdo. Se puser cor de rodapé no body, ela
+vaza pra peça toda.
+
+## Responsividade
+
+O design costuma vir em 393px (mobile). O arquivo entrega as duas versões:
+
+- **desktop = a canvas de 602px do MJML**, que é o layout padrão;
+- **mobile = `@media only screen and (max-width: 480px)`** no `mj-style`,
+  com os seletores da tabela acima. Os valores mobile são os literais do Figma.
+
+`fluid-on-mobile="true"` em `mj-image` — **menos no logo**, onde ele estica a
+arte até as bordas da tela e parece cortada. Logo leva `width` fixo menor ou
+padding lateral na seção.
+
+**Padronize corpo, saudação, botões e rodapé entre os e-mails da sequência; NÃO
+padronize o headline do hero.** O design varia o display de propósito (uma peça
+de urgência tem headline maior) e achatar tudo numa régua só mata a hierarquia.
+
+## Conferência visual
+
+Instale o Playwright **fora do repo** (não suje o `package.json`) e copie os
+scripts de `bin/` para lá. Como são ESM, o `import 'playwright'` resolve a partir
+do diretório do próprio script — `NODE_PATH` não funciona, por isso a cópia:
+
+```bash
+PW=/tmp/pw
+mkdir -p $PW && cd $PW && npm init -y && npm i playwright
+cp .claude/skills/figma-para-mjml/bin/*.mjs $PW/
+```
+
+Os scripts usam o Chrome do sistema (`channel: 'chrome'`), então **não baixam
+browser**. Abrem um de cada vez e fecham — não rode em paralelo, a RAM sofre.
+Passe caminho **absoluto** para o HTML:
+
+```bash
+node $PW/shot.mjs     "$PWD/dist/.../email.html" 375 /tmp/mobile.png
+node $PW/shot.mjs     "$PWD/dist/.../email.html" 700 /tmp/desktop.png
+node $PW/overflow.mjs "$PWD/dist/.../email.html" 375
+```
+
+Compare com o PNG do node (`get_screenshot` do Figma MCP + `curl`). Para olhar
+detalhe sem estourar contexto, recorte a região:
+`convert shot.png -crop 700x420+0+1330 +repage crop.png`.
+
+Use viewport de 900px de vez em quando: as calhas laterais só aparecem aí, e é
+onde erro de `mj-body` fica visível.
+
+## Don't
+
+- Não use HTML cru para layout. HTML inline só dentro de `mj-text`, e só para
+  formatação de texto ou as caixas com fundo/borda.
+- Não mude os textos do design — nem para corrigir o que parece erro. Espaço
+  duplo, travessão, emoji e caixa alta são intocáveis. `[PRIMEIRO NOME]` vira
+  `{$name|default('Estudante')}`; outras `[ASSIM]` viram `{$assim}`.
+- Não copie a regra `a[class*="mj-button"] { white-space: nowrap !important; }`
+  dos e-mails antigos — quebra CTA de texto longo.
+- Não invente `produto`/`fornecedor`/`curso` no href de redirect, e não invente
+  copy que o design não tem (gancho pro próximo e-mail, assinatura de rodapé).
+  Se o design não tem, pergunte ao usuário.
+- Não confie no build como validação de responsividade: ele compila 100% limpo
+  com a media query inteira morta.

--- a/.claude/skills/figma-para-mjml/bin/overflow.mjs
+++ b/.claude/skills/figma-para-mjml/bin/overflow.mjs
@@ -1,0 +1,45 @@
+// uso: node overflow.mjs <arquivo.html> <largura>
+// Critério de aceite do repo: scrollWidth == largura do viewport em 375px.
+// Um único width fixo maior que a tela empurra o corpo inteiro e o e-mail
+// chega torto no celular. O build do MJML NÃO pega isso.
+import { chromium } from 'playwright'
+
+const [file, widthArg] = process.argv.slice(2)
+if (!file) {
+  console.error('uso: node overflow.mjs <arquivo.html> <largura>')
+  process.exit(1)
+}
+const width = Number(widthArg || 375)
+
+const browser = await chromium.launch({ channel: 'chrome' })
+try {
+  const page = await browser.newPage({ viewport: { width, height: 900 } })
+  await page.goto('file://' + file, { waitUntil: 'networkidle', timeout: 60000 })
+  await page.waitForTimeout(800)
+  const report = await page.evaluate((vw) => {
+    const out = []
+    for (const el of document.querySelectorAll('*')) {
+      const r = el.getBoundingClientRect()
+      if (r.width > vw + 1 || r.right > vw + 1) {
+        const cs = getComputedStyle(el)
+        out.push({
+          tag: el.tagName,
+          cls: (el.getAttribute('class') || '').slice(0, 40),
+          w: Math.round(r.width),
+          right: Math.round(r.right),
+          cssWidth: cs.width,
+          attrWidth: el.getAttribute('width') || '',
+          inline: (el.getAttribute('style') || '').slice(0, 90),
+        })
+      }
+    }
+    return { scrollWidth: document.documentElement.scrollWidth, offenders: out }
+  }, width)
+  console.log('scrollWidth:', report.scrollWidth, '| viewport:', width)
+  console.log('elementos que estouram:', report.offenders.length)
+  // Os primeiros da lista são ancestrais empurrados; o culpado costuma estar
+  // no fim — procure width fixo em inline/attrWidth.
+  for (const o of report.offenders.slice(0, 25)) console.log(JSON.stringify(o))
+} finally {
+  await browser.close()
+}

--- a/.claude/skills/figma-para-mjml/bin/shot.mjs
+++ b/.claude/skills/figma-para-mjml/bin/shot.mjs
@@ -1,0 +1,27 @@
+// uso: node shot.mjs <arquivo.html> <largura> <saida.png>
+// Abre UM chrome por vez, tira screenshot de página inteira e fecha.
+// Usa o Chrome do sistema (channel: 'chrome') para não baixar browser.
+// Larguras úteis: 375 (mobile), 700 (desktop), 900 (para ver as calhas laterais).
+import { chromium } from 'playwright'
+
+const [file, widthArg, out] = process.argv.slice(2)
+if (!file || !out) {
+  console.error('uso: node shot.mjs <arquivo.html> <largura> <saida.png>')
+  process.exit(1)
+}
+const width = Number(widthArg || 602)
+
+const browser = await chromium.launch({ channel: 'chrome' })
+try {
+  const page = await browser.newPage({
+    viewport: { width, height: 900 },
+    deviceScaleFactor: 1,
+  })
+  await page.goto('file://' + file, { waitUntil: 'networkidle', timeout: 60000 })
+  await page.waitForTimeout(1200) // fontes do Google + imagens do imghost
+  await page.screenshot({ path: out, fullPage: true })
+  const h = await page.evaluate(() => document.body.scrollHeight)
+  console.log(`${out} ${width}x${h}`)
+} finally {
+  await browser.close()
+}

--- a/src/campanhas/r4-sequencia/sequenciar4-1.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-1.mjml
@@ -1,0 +1,509 @@
+<mjml>
+  <mj-head>
+    <mj-title>Vi seu nome nessa lista - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#F95F00"
+        color="#FFFFFF"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style inline="inline">
+      .bene-card {
+        border-radius: 16px;
+      }
+    </mj-style>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        .hero-band {
+          padding-left: 18px !important;
+          padding-right: 18px !important;
+        }
+        .hero-band > table > tbody > tr > td {
+          padding-left: 18px !important;
+          padding-right: 18px !important;
+        }
+        .hero-title div {
+          font-size: 26px !important;
+          line-height: 31px !important;
+        }
+        .hero-sub div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .light-card {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .light-card > table > tbody > tr > td {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .lead-text div {
+          font-size: 16px !important;
+          line-height: 21px !important;
+        }
+        .body-text div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .warn-box div {
+          font-size: 20px !important;
+          line-height: 25px !important;
+        }
+        .section-title div {
+          font-size: 22px !important;
+          line-height: 27px !important;
+        }
+        .bene-row {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .bene-row > table > tbody > tr > td {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .bene-icon {
+          width: 29% !important;
+        }
+        .bene-body {
+          width: 71% !important;
+        }
+        .bene-title div {
+          font-size: 15px !important;
+          line-height: 19px !important;
+        }
+        .bene-sub div {
+          font-size: 13px !important;
+          line-height: 18px !important;
+        }
+        .cta-btn table {
+          width: 100% !important;
+        }
+        .cta-btn a {
+          display: block !important;
+          width: auto !important;
+          font-size: 16px !important;
+        }
+        .footer-band {
+          padding-left: 18px !important;
+          padding-right: 18px !important;
+        }
+        .footer-band > table > tbody > tr > td {
+          padding-left: 18px !important;
+          padding-right: 18px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#910964" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- Hero -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/j2nwI.jpg"
+            alt="Professora sorrindo em sala de aula - San Educacional"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Título + Subtítulo + CTA 1 -->
+      <mj-section
+        background-color="#910964"
+        padding="20px 40px 40px 40px"
+        css-class="hero-band"
+      >
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-title"
+            font-size="36px"
+            font-weight="700"
+            line-height="42px"
+            letter-spacing="-1px"
+            color="#FFF8FD"
+            padding="0px 0px 14px 0px"
+          >
+            Vi seu nome nessa lista
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="hero-sub"
+            font-size="17px"
+            font-weight="400"
+            line-height="26px"
+            color="#EBCDE1"
+            padding="0px 0px 24px 0px"
+          >
+            Oportunidade exclusiva - Licenciatura em 6 meses!
+          </mj-text>
+
+          <mj-button
+            css-class="cta-btn"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="20px"
+            font-weight="700"
+            width="470px"
+            inner-padding="17px 20px"
+            padding="0px"
+          >
+            Garantir a minha vaga
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card claro - parte A -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px 22px 0px 0px"
+        padding="30px 30px 0px 30px"
+        css-class="light-card"
+      >
+        <mj-column>
+          <mj-text
+            css-class="lead-text"
+            font-size="19px"
+            font-weight="700"
+            line-height="25px"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            Oi {$name|default('Estudante')}, essa grande oportunidade é para
+            você que já fez ou está fazendo R2.
+          </mj-text>
+
+          <mj-text css-class="body-text" padding="0px 0px 20px 0px">
+            Se você já concluiu, está cursando ou até mesmo começou a
+            Formação Pedagógica ou Segunda Licenciatura e não
+            finalizou<b>, essa pode ser a oportunidade que faltava para
+            conquistar uma Licenciatura Plena.</b>
+          </mj-text>
+
+          <mj-text
+            css-class="body-text"
+            font-weight="700"
+            padding="0px 0px 20px 0px"
+          >
+            Graças ao aproveitamento da sua formação anterior, você pode
+            concluir uma Segunda Licenciatura em até 6 meses (tempo muito
+            reduzido de formação), sem precisar começar tudo novamente.
+          </mj-text>
+
+          <mj-text css-class="body-text" padding="0px">
+            E o melhor: não há redução da carga horária do diploma. Ao
+            final do curso, você recebe <b>uma Licenciatura Plena com
+            3.200 horas, válida em todo o território nacional.</b>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card claro - parte B -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="0px"
+        padding="28px 30px 0px 30px"
+        css-class="light-card"
+      >
+        <mj-column>
+          <mj-text css-class="body-text" padding="0px 0px 20px 0px">
+            Essa modalidade é diferenciada e extremamente difícil de
+            encontrar no mercado, pois permite uma conclusão em tempo
+            reduzido, mantendo a carga horária completa da formação.
+          </mj-text>
+
+          <mj-text css-class="body-text" padding="0px 0px 20px 0px">
+            Com a Licenciatura Plena, você amplia suas oportunidades para
+            <b>atuar na educação, participa de concursos</b> que exigem
+            formação plena e ainda pode<b> facilitar o ingresso em novas
+            Segundas Licenciaturas</b> no futuro.
+          </mj-text>
+
+          <mj-text align="center" css-class="warn-box" padding="0px">
+            <div
+              style="
+                background-color: #f95f00;
+                border-radius: 16px;
+                max-width: 440px;
+                margin: 0 auto;
+                padding: 22px 12px;
+              "
+            >
+              <div
+                style="
+                  font-family: Poppins, Arial, sans-serif;
+                  font-size: 26px;
+                  font-weight: 700;
+                  line-height: 30px;
+                  color: #ffffff;
+                  text-align: center;
+                "
+              >
+                ⚠️ Essa é uma condição especial e por tempo limitado.
+              </div>
+            </div>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card claro - título "Na SAN..." -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="0px"
+        padding="36px 30px 16px 30px"
+        css-class="light-card"
+      >
+        <mj-column>
+          <mj-text
+            css-class="section-title"
+            font-size="28px"
+            font-weight="700"
+            line-height="34px"
+            letter-spacing="-0.5px"
+            color="#8D005E"
+            padding="0px"
+          >
+            Na SAN, você não está sozinho em nenhuma etapa
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco 1 - Reconhecido pelo MEC -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="0px 30px 14px 30px"
+        css-class="bene-row"
+      >
+        <mj-group background-color="#FFFFFF" css-class="bene-card">
+          <mj-column
+            width="21%"
+            vertical-align="middle"
+            padding="12px"
+            css-class="bene-icon"
+          >
+            <mj-image
+              src="https://imghost.saneducacional.com.br/dw6XC.jpg"
+              alt="Grupo de profissionais se cumprimentando"
+              width="90px"
+              border-radius="14px"
+              padding="0px"
+              fluid-on-mobile="true"
+            />
+          </mj-column>
+          <mj-column
+            width="79%"
+            vertical-align="middle"
+            padding="12px 14px 12px 4px"
+            css-class="bene-body"
+          >
+            <mj-text
+              css-class="bene-title"
+              font-weight="700"
+              color="#050505"
+              font-size="17px"
+              line-height="22px"
+              padding="0px 0px 2px 0px"
+            >
+              Reconhecido pelo MEC
+            </mj-text>
+            <mj-text
+              css-class="bene-sub"
+              font-weight="400"
+              color="#5B4A55"
+              font-size="15px"
+              line-height="21px"
+              padding="0px"
+            >
+              Diploma com valor de graduação plena.
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+
+      <!-- Card branco 2 - Suporte humanizado -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="0px 30px 14px 30px"
+        css-class="bene-row"
+      >
+        <mj-group background-color="#FFFFFF" css-class="bene-card">
+          <mj-column
+            width="21%"
+            vertical-align="middle"
+            padding="12px"
+            css-class="bene-icon"
+          >
+            <mj-image
+              src="https://imghost.saneducacional.com.br/CB2O3.jpg"
+              alt="Consultor orientando uma estudante"
+              width="90px"
+              border-radius="14px"
+              padding="0px"
+              fluid-on-mobile="true"
+            />
+          </mj-column>
+          <mj-column
+            width="79%"
+            vertical-align="middle"
+            padding="12px 14px 12px 4px"
+            css-class="bene-body"
+          >
+            <mj-text
+              css-class="bene-title"
+              font-weight="700"
+              color="#050505"
+              font-size="17px"
+              line-height="22px"
+              padding="0px 0px 2px 0px"
+            >
+              Suporte humanizado
+            </mj-text>
+            <mj-text
+              css-class="bene-sub"
+              font-weight="400"
+              color="#5B4A55"
+              font-size="15px"
+              line-height="21px"
+              padding="0px"
+            >
+              Orientação do início ao fim do curso.
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+
+      <!-- Card branco 3 - Para crescer rápido -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="0px 30px 14px 30px"
+        css-class="bene-row"
+      >
+        <mj-group background-color="#FFFFFF" css-class="bene-card">
+          <mj-column
+            width="21%"
+            vertical-align="middle"
+            padding="12px"
+            css-class="bene-icon"
+          >
+            <mj-image
+              src="https://imghost.saneducacional.com.br/DuvKG.jpg"
+              alt="Equipe reunida trabalhando com notebooks"
+              width="90px"
+              border-radius="14px"
+              padding="0px"
+              fluid-on-mobile="true"
+            />
+          </mj-column>
+          <mj-column
+            width="79%"
+            vertical-align="middle"
+            padding="12px 14px 12px 4px"
+            css-class="bene-body"
+          >
+            <mj-text
+              css-class="bene-title"
+              font-weight="700"
+              color="#050505"
+              font-size="17px"
+              line-height="22px"
+              padding="0px 0px 2px 0px"
+            >
+              Para crescer rápido
+            </mj-text>
+            <mj-text
+              css-class="bene-sub"
+              font-weight="400"
+              color="#5B4A55"
+              font-size="15px"
+              line-height="21px"
+              padding="0px"
+            >
+              No seu ritmo.
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+
+      <!-- Clique abaixo... + CTA 2 -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="0px 0px 22px 22px"
+        padding="24px 30px 36px 30px"
+        css-class="light-card"
+      >
+        <mj-column>
+          <mj-text css-class="body-text" padding="0px 0px 24px 0px">
+            Clique abaixo e descubra se você pode aproveitar essa
+            oportunidade.
+          </mj-text>
+
+          <mj-button
+            css-class="cta-btn"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="20px"
+            font-weight="700"
+            width="440px"
+            inner-padding="11px 20px"
+            padding="0px"
+          >
+            QUERO SABER MAIS
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Rodapé -->
+      <mj-section
+        background-color="#910964"
+        padding="34px 34px 30px 34px"
+        css-class="footer-band"
+      >
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="15px"
+            font-weight="600"
+            line-height="22px"
+            color="#E9C8DE"
+            padding="0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#B04C8F"
+            padding="18px 0px 0px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="15px"
+            font-weight="400"
+            line-height="22px"
+            padding="16px 0px 0px 0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #deb0cf; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/campanhas/r4-sequencia/sequenciar4-2.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-2.mjml
@@ -1,0 +1,343 @@
+<mjml>
+  <mj-head>
+    <mj-title>O Brasil vai faltar 235 mil professores - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#F95F00"
+        color="#FFFFFF"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        .bloco-branco > table > tbody > tr > td {
+          padding: 24px 18px 36px 18px !important;
+        }
+        .hero-titulo div {
+          font-size: 26px !important;
+          line-height: 32px !important;
+        }
+        .hero-sub div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .alerta div {
+          font-size: 17px !important;
+          line-height: 22px !important;
+        }
+        .texto-corpo div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .subtitulo-rosa div {
+          font-size: 16px !important;
+          line-height: 24px !important;
+        }
+        .legenda-card {
+          font-size: 18px !important;
+          line-height: 25px !important;
+          padding: 16px 18px !important;
+        }
+        .texto-caixa {
+          font-size: 15px !important;
+          line-height: 20px !important;
+        }
+        .frase-final div {
+          font-size: 24px !important;
+          line-height: 31px !important;
+        }
+        .cta-principal table {
+          width: 100% !important;
+        }
+        .cta-principal a {
+          display: block !important;
+          width: auto !important;
+          font-size: 16px !important;
+          line-height: 22px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#910964" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- Barra do logo -->
+      <mj-section background-color="#FAEDF6" padding="12px 20px 13px 20px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/0z1U2.jpg"
+            alt="SAN Educacional"
+            width="259px"
+            padding="0px"
+            align="center"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Hero (foto) -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/CsFWc.jpg"
+            alt="Estudante sorridente com caderno em uma biblioteca"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Título + subtítulo do hero -->
+      <mj-section background-color="#910964" padding="0px 40px 44px 40px">
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-titulo"
+            font-size="34px"
+            line-height="40px"
+            font-weight="700"
+            letter-spacing="-0.02em"
+            color="#FFF8FD"
+            padding="6px 0px 0px 0px"
+          >
+            O Brasil vai faltar<br />235 mil professores
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="hero-sub"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#EBCDE1"
+            padding="16px 0px 0px 0px"
+          >
+            E isso é uma oportunidade, não um problema — se você se preparar
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Bloco branco -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px"
+        padding="34px 30px 48px 30px"
+        css-class="bloco-branco"
+      >
+        <mj-column width="542px">
+          <mj-text
+            css-class="alerta"
+            font-size="20px"
+            line-height="26px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 26px 0px"
+          >
+            ALERTA: O Brasil poderá enfrentar um déficit de até 235 mil
+            professores nos próximos anos.
+          </mj-text>
+
+          <mj-text css-class="texto-corpo" padding="0px 0px 26px 0px">
+            Enquanto milhares de profissionais se aposentam e a
+            <b>demanda por novos professores cresce,</b> uma modalidade
+            exclusiva acaba de surgir para quem já fez, está cursando ou
+            iniciou a sua <b>R2 Formação Pedagógica ou Segunda
+            Licenciatura.</b>
+          </mj-text>
+
+          <mj-text
+            align="left"
+            padding="0px 0px 26px 0px"
+            css-class="card-foto"
+          >
+            <div
+              style="
+                background-color: #8d005e;
+                border-radius: 18px;
+                overflow: hidden;
+              "
+            >
+              <img
+                src="https://imghost.saneducacional.com.br/3xqh9.jpg"
+                alt="Dois profissionais conversando durante um atendimento"
+                style="
+                  width: 100%;
+                  display: block;
+                  border-radius: 18px 18px 0px 0px;
+                "
+              />
+              <div
+                class="legenda-card"
+                style="
+                  font-family: Poppins, Arial, sans-serif;
+                  font-size: 22px;
+                  font-weight: 700;
+                  line-height: 30px;
+                  color: #fff8fd;
+                  letter-spacing: -0.01em;
+                  padding: 20px 22px;
+                "
+              >
+                Estamos à disposição para ajudar você a crescer!
+              </div>
+            </div>
+          </mj-text>
+
+          <mj-text css-class="texto-corpo" padding="0px 0px 26px 0px">
+            Agora, é possível conquistar uma <b>Licenciatura Plena em até 6
+            meses, aproveitando a formação que você já possui.</b> E o
+            melhor: sem redução da carga horária. Ao final, você recebe um
+            diploma de<b> 3.200 horas,</b> válido em todo o território
+            nacional.
+          </mj-text>
+
+          <mj-text
+            css-class="subtitulo-rosa"
+            font-size="18px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 26px 0px"
+          >
+            Mas por que essa oportunidade merece sua atenção?
+          </mj-text>
+
+          <mj-text css-class="texto-corpo" padding="0px 0px 26px 0px">
+            <b>O Instituto Semesp projeta um déficit de até 235 mil
+            professores na educação básica brasileira até 2040.</b> Além
+            disso, outro levantamento aponta que 57,5% dos professores das
+            redes estaduais devem se aposentar até 2034.
+          </mj-text>
+
+          <mj-text padding="0px 0px 26px 0px" css-class="caixa-destaque">
+            <a
+              href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+              style="text-decoration: none;"
+            >
+              <div
+                style="
+                  background-color: #ffffff;
+                  border: 1px solid #f0dcea;
+                  border-radius: 14px;
+                  padding: 18px 20px;
+                "
+              >
+                <div
+                  class="texto-caixa"
+                  style="
+                    font-family: Poppins, Arial, sans-serif;
+                    font-size: 16px;
+                    font-weight: 700;
+                    line-height: 22px;
+                    color: #050505;
+                  "
+                >
+                  Na prática, isso significa que o mercado precisará
+                  contratar milhares de novos profissionais nos próximos
+                  anos. <span style="color: #f95f00;">→</span>
+                </div>
+              </div>
+            </a>
+          </mj-text>
+
+          <mj-text css-class="texto-corpo" padding="0px 0px 26px 0px">
+            Quem aproveitar essa modalidade para conquistar a Licenciatura
+            Plena estará mais preparado para disputar vagas, atender aos
+            requisitos de processos seletivos que exigem formação plena e
+            ainda abrir caminho para futuras Segundas Licenciaturas.
+          </mj-text>
+
+          <mj-text
+            css-class="texto-corpo"
+            font-weight="700"
+            padding="0px 0px 38px 0px"
+          >
+            O cenário é favorável, mas a modalidade em tempo reduzido é uma
+            condição especial e não há garantia de que permanecerá
+            disponível por muito tempo.
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="frase-final"
+            font-size="30px"
+            line-height="38px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 30px 0px"
+          >
+            Quem se antecipa chega na frente.
+          </mj-text>
+
+          <mj-button
+            css-class="cta-principal"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#F95F00"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="19px"
+            font-weight="700"
+            line-height="25px"
+            width="420px"
+            inner-padding="14px 22px"
+            padding="0px"
+            align="center"
+          >
+            QUERO APROVEITAR ESSA OPORTUNIDADE
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçador -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="34px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Rodapé -->
+      <mj-section background-color="#910964" padding="0px 30px 40px 30px">
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="14px"
+            line-height="20px"
+            font-weight="700"
+            color="#E9C8DE"
+            padding="0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#B04C8F"
+            padding="18px 0px 0px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="14px"
+            line-height="20px"
+            font-weight="400"
+            padding="16px 0px 0px 0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #deb0cf; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/campanhas/r4-sequencia/sequenciar4-3.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-3.mjml
@@ -1,0 +1,406 @@
+<mjml>
+  <mj-head>
+    <mj-title>Achei que ia levar anos. Levou 6 meses. - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#F95F00"
+        color="#FFFFFF"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        /* Logo: fluid-on-mobile estica a arte até as bordas da tela.
+           Respiro lateral no td da própria mj-image. */
+        .logo-img {
+          padding-left: 56px !important;
+          padding-right: 56px !important;
+        }
+        .hero-title {
+          padding-left: 22px !important;
+          padding-right: 22px !important;
+        }
+        .hero-title div {
+          font-size: 26px !important;
+          line-height: 32px !important;
+        }
+        .hero-sub div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .card-section > table > tbody > tr > td {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .body-copy div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .greeting div {
+          font-size: 17px !important;
+          line-height: 24px !important;
+        }
+        .highlight-box div {
+          font-size: 19px !important;
+          line-height: 26px !important;
+        }
+        .quote-inner {
+          padding: 16px 14px !important;
+        }
+        .quote-text {
+          font-size: 17px !important;
+          line-height: 26px !important;
+        }
+        .cta-top table,
+        .cta-final table {
+          width: 100% !important;
+        }
+        .cta-top a,
+        .cta-final a {
+          display: block !important;
+          width: auto !important;
+        }
+        .cta-top a {
+          font-size: 16px !important;
+        }
+        .cta-final a {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#910964" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- Logo -->
+      <mj-section background-color="#910964" padding="18px 0px 40px 0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/K72Rl.jpg"
+            alt="SAN Educacional"
+            width="394px"
+            padding="0px"
+            css-class="logo-img"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Hero -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/Wbbcm.jpg"
+            alt="Professora sorridente em ambiente corporativo"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Headline + Subtítulo + CTA topo -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-title"
+            font-size="34px"
+            line-height="40px"
+            font-weight="700"
+            letter-spacing="-0.03em"
+            padding="4px 34px 0px 34px"
+          >
+            <span style="color: #fff8fd">&quot;Achei que ia levar anos. </span
+            ><span style="color: #ffb765">Levou 6 meses.&quot;</span>
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="hero-sub"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#EBCDE1"
+            padding="14px 42px 0px 42px"
+          >
+            Uma modalidade tão nova que você pode ser dos primeiros a viver
+            isso
+          </mj-text>
+
+          <mj-button
+            css-class="cta-top"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="19px"
+            line-height="1.2"
+            font-weight="700"
+            width="486px"
+            inner-padding="15px 20px"
+            padding="28px 0px 0px 0px"
+          >
+            Quero saber mais
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="42px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco - parte A -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px 22px 0px 0px"
+        padding="30px 30px 0px 30px"
+        css-class="card-section"
+      >
+        <mj-column width="522px">
+          <mj-text
+            css-class="greeting"
+            font-size="19px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            Oi {$name|default('Estudante')}, tudo bem?
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            Toda vez que alguém escuta &quot;Licenciatura Plena&quot;, a
+            primeira reação é sempre a mesma:
+          </mj-text>
+
+          <mj-text
+            css-class="body-copy"
+            font-weight="700"
+            padding="0px 0px 20px 0px"
+          >
+            &quot;Isso não vai levar uns 2 ou 3 anos?&quot;
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            Na maioria dos casos, sim.
+          </mj-text>
+
+          <mj-text
+            css-class="body-copy"
+            font-weight="700"
+            padding="0px 0px 20px 0px"
+          >
+            Mas não na nova modalidade exclusiva criada para quem já fez, está
+            cursando ou iniciou a R2.
+          </mj-text>
+
+          <mj-text
+            css-class="body-copy"
+            font-weight="700"
+            padding="0px 0px 20px 0px"
+          >
+            Aproveitando a formação que você já possui, agora é possível
+            conquistar uma Licenciatura Plena em até 6 meses
+            <span style="font-weight: 500"
+              >— um tempo extremamente reduzido para uma formação desse
+              nível.</span
+            >
+          </mj-text>
+
+          <mj-text
+            css-class="body-copy"
+            font-weight="700"
+            color="#DF5500"
+            padding="0px 0px 20px 0px"
+          >
+            E o melhor: sem redução da carga horária. Ao concluir, você
+            recebe um diploma de 3.200 horas, válido em todo o território
+            nacional.
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            É por isso que essa modalidade surpreende tanta gente. Quem
+            conhece pela primeira vez acredita que precisará estudar por
+            anos, mas descobre que pode
+            <b
+              >aproveitar toda a formação já realizada e concluir a
+              graduação em poucos meses.</b
+            >
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="highlight-box"
+            font-weight="700"
+            color="#8D005E"
+            font-size="24px"
+            line-height="32px"
+            padding="10px 0px 0px 0px"
+          >
+            ESSA É UMA OPORTUNIDADE REALMENTE DIFERENCIADA E MUITO DIFÍCIL
+            DE ENCONTRAR NO MERCADO.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco - parte B (depoimento) -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="20px 30px 20px 30px"
+        css-class="card-section"
+      >
+        <mj-column width="522px">
+          <mj-text css-class="quote-box" padding="0px">
+            <div
+              class="quote-inner"
+              style="
+                background-color: #8d005e;
+                border-radius: 18px;
+                padding: 20px 18px;
+              "
+            >
+              <div
+                class="quote-text"
+                style="
+                  font-family: Poppins, Arial, sans-serif;
+                  font-size: 20px;
+                  font-weight: 400;
+                  line-height: 30px;
+                  letter-spacing: -0.02em;
+                  color: #fff8fd;
+                "
+              >
+                &quot;Recebi todas as orientações, entendi como funcionava a
+                modalidade e percebi que conseguiria conquistar minha
+                Formação Pedagógica em um tempo que eu jamais imaginava.
+                Hoje estou realizando meu sonho de atuar na educação e já
+                quero continuar minha formação com uma Segunda
+                Licenciatura.&quot;
+              </div>
+              <div style="padding: 14px 0px 0px 0px">
+                <span
+                  style="
+                    display: inline-block;
+                    background-color: #9d2374;
+                    border-radius: 16px;
+                    padding: 7px 14px;
+                    font-family: Poppins, Arial, sans-serif;
+                    font-size: 13px;
+                    font-weight: 700;
+                    line-height: 1.2;
+                    color: #fff8fd;
+                  "
+                  >— Maria R. Almeida</span
+                >
+              </div>
+            </div>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco - parte C -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="0px 0px 22px 22px"
+        padding="0px 30px 32px 30px"
+        css-class="card-section"
+      >
+        <mj-column width="522px">
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            Com a Licenciatura Plena, você amplia suas oportunidades
+            profissionais, fortalece seu currículo e ainda abre caminho
+            para cursar <b>novas Segundas Licenciaturas no futuro.</b>
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px">
+            ⚠️ Mas atenção: essa modalidade exclusiva, com
+            <b>conclusão em até 6 meses e aproveitamento da formação</b>
+            que você já possui, é uma condição especial e pode não
+            permanecer disponível por muito tempo.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="38px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- CTA final -->
+      <mj-section background-color="#910964" padding="0px 40px 0px 40px">
+        <mj-column>
+          <mj-button
+            css-class="cta-final"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#F95F00"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="19px"
+            line-height="26px"
+            font-weight="700"
+            width="496px"
+            inner-padding="14px 18px"
+            padding="0px"
+          >
+            QUERO APROVEITAR ESSA OPORTUNIDADE
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="46px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Rodapé -->
+      <mj-section background-color="#910964" padding="0px 30px 0px 30px">
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="600"
+            color="#E9C8DE"
+            padding="0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#B04C8F"
+            padding="18px 0px 0px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="400"
+            padding="16px 0px 34px 0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #deb0cf; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/campanhas/r4-sequencia/sequenciar4-4.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-4.mjml
@@ -1,0 +1,405 @@
+<mjml>
+  <mj-head>
+    <mj-title>Seu perfil chamou atenção - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#F95F00"
+        color="#FFFFFF"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        /* css-class de mj-section cai no <div> externo; o padding vive no <td>
+           do <table> filho. Por isso o seletor precisa do "> table". */
+        .card-pad > table > tbody > tr > td {
+          padding-left: 18px !important;
+          padding-right: 18px !important;
+        }
+        /* css-class de mj-text cai no <td> (font-size:0px); o texto é estilizado
+           no <div> interno. Sem o "div" o override não pega. */
+        .hero-title div {
+          font-size: 26px !important;
+          line-height: 32px !important;
+        }
+        .hero-sub {
+          padding-left: 8px !important;
+          padding-right: 8px !important;
+        }
+        .hero-sub div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .greeting div {
+          font-size: 17px !important;
+          line-height: 24px !important;
+        }
+        .body-copy div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .tl-title div {
+          font-size: 16px !important;
+          line-height: 21px !important;
+        }
+        .tl-sub div {
+          font-size: 13px !important;
+          line-height: 19px !important;
+        }
+        .check-item div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .closing-note div {
+          font-size: 14px !important;
+          line-height: 21px !important;
+        }
+        .cta-btn a {
+          font-size: 17px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#910964" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- Hero -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/HM0mM.jpg"
+            alt="Estudante sorrindo em frente ao notebook - San Educacional"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="30px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Título + subtítulo do hero -->
+      <mj-section background-color="#910964" padding="0px 34px">
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-title"
+            font-size="34px"
+            line-height="40px"
+            font-weight="700"
+            letter-spacing="-0.02em"
+            color="#FFF8FD"
+            padding="0px"
+          >
+            ⚠️ Seu perfil<br />chamou atenção
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="hero-sub"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#EBCDE1"
+            padding="14px 0px 0px 0px"
+          >
+            Quem já tem R2 está sendo mais valorizado do que imagina
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="26px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco - parte A -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px 22px 0px 0px"
+        padding="36px 30px 0px 30px"
+        css-class="card-pad"
+      >
+        <mj-column width="542px">
+          <mj-text
+            css-class="greeting"
+            font-size="19px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            Oi {$name|default('Estudante')}, seu histórico chamou nossa atenção por um motivo importante.
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            Se você já concluiu, está cursando ou iniciou uma
+            <b>Licenciatura ou a Formação Pedagógica (R2)</b>, pode fazer
+            parte de um grupo que tem acesso a uma modalidade exclusiva para
+            conquistar uma nova <b>Licenciatura Plena em até 6 meses.</b>
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            Sua formação é aproveitada, permitindo concluir uma nova
+            Licenciatura em um tempo muito menor que o tradicional,
+            <b>sem redução da carga horária.</b> Ao final, você recebe um
+            <b>diploma de 3.200 horas</b>, válido em todo o Brasil.
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px">
+            Agora imagine dois caminhos.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco - timeline item 1 -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="10px 30px 0px 30px"
+        css-class="card-pad"
+      >
+        <mj-group>
+          <mj-column width="13%" css-class="dot-col">
+            <mj-text padding="4px 0px 0px 0px">
+              <div
+                style="
+                  width: 34px;
+                  height: 34px;
+                  line-height: 34px;
+                  font-size: 1px;
+                  background-color: #f95f00;
+                  border-radius: 999px;
+                "
+              >
+                &nbsp;
+              </div>
+            </mj-text>
+          </mj-column>
+          <mj-column width="87%" css-class="dot-text">
+            <mj-text
+              css-class="tl-title"
+              font-size="18px"
+              line-height="24px"
+              font-weight="700"
+              color="#050505"
+              padding="0px 0px 2px 0px"
+            >
+              No primeiro, você mantém apenas a formação
+            </mj-text>
+            <mj-text
+              css-class="tl-sub"
+              font-size="15px"
+              line-height="22px"
+              font-weight="400"
+              color="#5B4A55"
+              padding="0px"
+            >
+              que já possui.
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+
+      <!-- Card branco - timeline item 2 -->
+      <mj-section
+        background-color="#FFF8FD"
+        padding="18px 30px 0px 30px"
+        css-class="card-pad"
+      >
+        <mj-group>
+          <mj-column width="13%" css-class="dot-col">
+            <mj-text padding="4px 0px 0px 0px">
+              <div
+                style="
+                  width: 34px;
+                  height: 34px;
+                  line-height: 34px;
+                  font-size: 1px;
+                  background-color: #bb0185;
+                  border-radius: 999px;
+                "
+              >
+                &nbsp;
+              </div>
+            </mj-text>
+          </mj-column>
+          <mj-column width="87%" css-class="dot-text">
+            <mj-text
+              css-class="tl-title"
+              font-size="18px"
+              line-height="24px"
+              font-weight="700"
+              color="#050505"
+              padding="0px 0px 2px 0px"
+            >
+              No segundo, aproveita essa condição especial,  conquista uma
+              nova Licenciatura Plena
+            </mj-text>
+            <mj-text
+              css-class="tl-sub"
+              font-size="15px"
+              line-height="22px"
+              font-weight="400"
+              color="#5B4A55"
+              padding="0px"
+            >
+              em apenas 6 meses e amplia suas oportunidades profissionais.
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+
+      <!-- Card branco - parte B -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="0px 0px 22px 22px"
+        padding="26px 30px 40px 30px"
+        css-class="card-pad"
+      >
+        <mj-column width="542px">
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            As duas possibilidades começam do mesmo ponto: a formação que
+            você já concluiu ou está cursando. A diferença está na decisão
+            que você toma hoje.
+          </mj-text>
+
+          <!-- Checklist: um mj-text por item para o respiro entre itens ficar
+               maior que o entrelinhas de um item que quebra em 2 linhas -->
+          <mj-text
+            css-class="check-item"
+            font-size="17px"
+            line-height="24px"
+            font-weight="400"
+            color="#050505"
+            padding="0px 0px 10px 0px"
+          >
+            ✅ Nova Licenciatura Plena em até 6 meses
+          </mj-text>
+
+          <mj-text
+            css-class="check-item"
+            font-size="17px"
+            line-height="24px"
+            font-weight="400"
+            color="#050505"
+            padding="0px 0px 10px 0px"
+          >
+            ✅ Diploma completo com 3.200 horas
+          </mj-text>
+
+          <mj-text
+            css-class="check-item"
+            font-size="17px"
+            line-height="24px"
+            font-weight="400"
+            color="#050505"
+            padding="0px 0px 10px 0px"
+          >
+            ✅ Aproveitamento da formação já realizada
+          </mj-text>
+
+          <mj-text
+            css-class="check-item"
+            font-size="17px"
+            line-height="24px"
+            font-weight="400"
+            color="#050505"
+            padding="0px 0px 20px 0px"
+          >
+            ✅ Modalidade exclusiva e por tempo limitado
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px">
+            Qual desses caminhos você escolhe para o seu futuro?
+          </mj-text>
+
+          <mj-button
+            css-class="cta-btn"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#F95F00"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="19px"
+            font-weight="700"
+            line-height="1.3"
+            width="100%"
+            inner-padding="14px 18px"
+            padding="6px 0px 22px 0px"
+          >
+            QUERO GARANTIR A MODALIDADE ESPECIAL
+          </mj-button>
+
+          <mj-text
+            align="center"
+            css-class="closing-note"
+            font-size="16px"
+            line-height="24px"
+            font-weight="400"
+            color="#5B4A55"
+            padding="0px"
+          >
+            Conte com a San Educacional para continuar evoluindo com você.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Espaçamento -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column>
+          <mj-spacer height="36px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- Rodapé -->
+      <mj-section background-color="#910964" padding="0px 30px 24px 30px">
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="600"
+            color="#E9C8DE"
+            padding="0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#B04C8F"
+            padding="18px 0px 0px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="400"
+            padding="16px 0px 0px 0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #deb0cf; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/campanhas/r4-sequencia/sequenciar4-5.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-5.mjml
@@ -1,0 +1,371 @@
+<mjml>
+  <mj-head>
+    <mj-title>Multiplique sua qualificação - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#F95F00"
+        color="#FFFFFF"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        .badge-section > table > tbody > tr > td {
+          padding: 12px 6px 0px 16px !important;
+        }
+        .hero-title div {
+          font-size: 30px !important;
+          line-height: 34px !important;
+          letter-spacing: 2px !important;
+        }
+        .hero-sub div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .greeting div {
+          font-size: 17px !important;
+          line-height: 24px !important;
+        }
+        .body-copy div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .destaque-para div {
+          font-size: 15px !important;
+          line-height: 25px !important;
+        }
+        .card-section > table > tbody > tr > td {
+          padding: 24px 16px !important;
+        }
+        .check-box-text {
+          font-size: 17px !important;
+          line-height: 27px !important;
+        }
+        .consultor-box {
+          padding: 16px 16px 18px 16px !important;
+        }
+        .consultor-text {
+          font-size: 17px !important;
+          line-height: 24px !important;
+        }
+        .cta-full table,
+        .cta-hero table {
+          width: 100% !important;
+        }
+        .cta-full a,
+        .cta-hero a {
+          display: block !important;
+          width: auto !important;
+          font-size: 15px !important;
+          line-height: 21px !important;
+        }
+        .footer-section > table > tbody > tr > td {
+          padding: 24px 16px 26px 16px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#910964" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- Faixa da pílula "CONDIÇÃO ESPECIAL" -->
+      <mj-section
+        background-color="#910964"
+        padding="16px 9px 0px 26px"
+        css-class="badge-section"
+      >
+        <mj-column>
+          <mj-text align="right" padding="0px">
+            <span
+              style="
+                display: inline-block;
+                background-color: #f95f00;
+                border-radius: 999px;
+                padding: 6px 16px;
+                font-family: Poppins, Arial, sans-serif;
+                font-size: 11px;
+                line-height: 14px;
+                font-weight: 700;
+                letter-spacing: 1.1px;
+                color: #ffffff;
+              "
+              >CONDIÇÃO ESPECIAL</span
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Hero -->
+      <mj-section background-color="#910964" padding="0px">
+        <mj-column padding="0px">
+          <mj-image
+            src="https://imghost.saneducacional.com.br/0Blko.jpg"
+            alt="Professora em sala de aula"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- Título -->
+      <mj-section background-color="#910964" padding="4px 18px 0px 18px">
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-title"
+            font-size="40px"
+            line-height="48px"
+            font-weight="700"
+            letter-spacing="4px"
+            color="#FFF8FD"
+            padding="0px"
+          >
+            <span style="color: #ffb765">Multiplique</span> sua qualificação
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Subtítulo -->
+      <mj-section background-color="#910964" padding="16px 30px 0px 30px">
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="hero-sub"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#EBCDE1"
+            padding="0px"
+          >
+            Essa condição especial não costuma ficar disponível pra sempre
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- CTA topo -->
+      <mj-section background-color="#910964" padding="28px 60px 40px 60px">
+        <mj-column>
+          <mj-button
+            css-class="cta-hero"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="19px"
+            line-height="24px"
+            font-weight="700"
+            width="100%"
+            inner-padding="16px 20px"
+            padding="0px"
+          >
+            Quero saber mais
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- Card branco -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px"
+        padding="34px 30px 36px 30px"
+        css-class="card-section"
+      >
+        <mj-column width="542px">
+          <mj-text
+            css-class="greeting"
+            font-size="19px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            Direto ao ponto, {$name|default('Estudante')}.
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 20px 0px">
+            A modalidade especial que permite concluir uma nova
+            <b>Licenciatura Plena em até 6 meses,</b> com aproveitamento da
+            formação que você já possui, não tem prazo de continuidade
+            garantido.
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 22px 0px">
+            Se você já concluiu, está
+            <b
+              >cursando ou iniciou uma Licenciatura ou a Formação Pedagógica
+              (R2), essa é uma oportunidade exclusiva para ampliar sua
+              formação</b
+            >
+            em um tempo muito menor que o tradicional.
+          </mj-text>
+
+          <mj-text
+            css-class="destaque-para"
+            font-weight="700"
+            color="#8D005E"
+            font-size="16px"
+            line-height="28px"
+            letter-spacing="-0.44px"
+            padding="0px 0px 24px 0px"
+          >
+            Isso não é discurso de vendedor. É a realidade: condições
+            especiais como essa não costumam ficar disponíveis para sempre e
+            ninguém pode afirmar com certeza até quando ela continuará ativa.
+          </mj-text>
+
+          <mj-text padding="0px 0px 24px 0px">
+            <div
+              style="
+                background-color: #8d005e;
+                border-radius: 18px;
+                padding: 24px 26px;
+              "
+            >
+              <div
+                class="check-box-text"
+                style="
+                  font-family: Poppins, Arial, sans-serif;
+                  font-size: 21px;
+                  line-height: 33px;
+                  font-weight: 400;
+                  letter-spacing: -0.78px;
+                  color: #fff8fd;
+                "
+              >
+                ✅ Nova Licenciatura Plena em <b>até 6 meses</b><br />
+                ✅ Diploma completo com <b>3.200 horas</b><br />
+                ✅ Aproveitamento da <b>formação já realizada</b><br />
+                ✅ <b>Mais oportunidades</b> na área da educação
+              </div>
+            </div>
+          </mj-text>
+
+          <mj-text css-class="body-copy" padding="0px 0px 26px 0px">
+            É justamente essa combinação que torna essa modalidade tão
+            diferenciada.
+            <b>E é por isso que quem já garantiu sua vaga decidiu não esperar.</b>
+          </mj-text>
+
+          <mj-button
+            css-class="cta-full"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="19px"
+            line-height="24px"
+            font-weight="700"
+            width="100%"
+            inner-padding="16px 20px"
+            padding="0px 0px 30px 0px"
+          >
+            GARANTIR MINHA VAGA NESSA MODALIDADE
+          </mj-button>
+
+          <mj-image
+            src="https://imghost.saneducacional.com.br/TIcHh.jpg"
+            alt="Equipe de atendimento San Educacional"
+            width="542px"
+            border-radius="28px 28px 0px 0px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+
+          <mj-text padding="0px">
+            <div
+              class="consultor-box"
+              style="
+                background-color: #8d005e;
+                border-radius: 0px 0px 28px 28px;
+                padding: 20px 22px 24px 22px;
+              "
+            >
+              <div
+                class="consultor-text"
+                style="
+                  font-family: Poppins, Arial, sans-serif;
+                  font-size: 21px;
+                  line-height: 29px;
+                  font-weight: 700;
+                  letter-spacing: -0.38px;
+                  color: #fff8fd;
+                "
+              >
+                Fale agora com nosso atendimento e saiba como garantir sua
+                vaga
+              </div>
+            </div>
+          </mj-text>
+
+          <mj-button
+            css-class="cta-full"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            font-size="19px"
+            line-height="24px"
+            font-weight="700"
+            width="100%"
+            inner-padding="16px 20px"
+            padding="28px 0px 0px 0px"
+          >
+            FALAR COM UM CONSULTOR
+          </mj-button>
+
+          <mj-text
+            align="center"
+            font-size="15px"
+            line-height="23px"
+            font-weight="400"
+            color="#5B4A55"
+            padding="30px 0px 0px 0px"
+          >
+            Conte com a San Educacional para continuar evoluindo com você!<br />
+            Atenciosamente, Equipe San Educacional.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Rodapé -->
+      <mj-section
+        background-color="#910964"
+        padding="28px 30px 30px 30px"
+        css-class="footer-section"
+      >
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="14px"
+            line-height="20px"
+            font-weight="600"
+            color="#E9C8DE"
+            padding="0px 0px 24px 0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#B04C8F"
+            padding="0px 0px 14px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="400"
+            padding="0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #deb0cf; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/campanhas/r4-sequencia/sequenciar4-6.mjml
+++ b/src/campanhas/r4-sequencia/sequenciar4-6.mjml
@@ -1,0 +1,296 @@
+<mjml>
+  <mj-head>
+    <mj-title>Última chamada - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#8D005E"
+        color="#ffffff"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        .headline div {
+          font-size: 30px !important;
+          line-height: 34px !important;
+        }
+        .subheadline div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .card-lead div {
+          font-size: 17px !important;
+          line-height: 24px !important;
+        }
+        .card-body div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .card-title div {
+          font-size: 20px !important;
+          line-height: 26px !important;
+        }
+        .check-card div {
+          font-size: 14px !important;
+          line-height: 20px !important;
+        }
+        .btn-wide table {
+          width: 100% !important;
+        }
+        .btn-wide a {
+          display: block !important;
+          width: auto !important;
+          font-size: 16px !important;
+        }
+        .hero-pad > table > tbody > tr > td,
+        .card-pad > table > tbody > tr > td {
+          padding-left: 14px !important;
+          padding-right: 14px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <!-- Canvas do documento em preto: é a cor dominante da peça, e a calha lateral
+       preta no desktop lê como intencional. O wrapper não pinta nada — cada
+       mj-section declara o próprio fundo (#050505 no topo, #F95F00 no rodapé),
+       sem depender de herança do body. -->
+  <mj-body background-color="#050505" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- S1: Hero -->
+      <mj-section background-color="#050505" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/AjITk.jpg"
+            alt="Homem de óculos sorrindo, de braços cruzados, em uma sala de aula, com a logo San Educacional"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- S2: Headline + subtítulo + CTA laranja -->
+      <mj-section
+        background-color="#050505"
+        padding="26px 28px 50px 28px"
+        css-class="hero-pad"
+      >
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="headline"
+            font-size="44px"
+            line-height="48px"
+            font-weight="700"
+            letter-spacing="-0.02em"
+            color="#FFF8FD"
+            padding="0px 0px 26px 0px"
+          >
+            <span style="color: #FFB765">Última chamada,</span><br />{$name|default('Estudante')}
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="subheadline"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#C8C2C6"
+            padding="0px 26px 30px 26px"
+          >
+            Última mensagem enquanto a condição especial ainda existe
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#F95F00"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="18px"
+            line-height="24px"
+            font-weight="700"
+            align="center"
+            width="480px"
+            inner-padding="18px 20px"
+            padding="0px"
+          >
+            Quero saber mais
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- S3: Card claro -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px"
+        padding="28px"
+        css-class="card-pad"
+      >
+        <mj-column width="546px">
+          <mj-text
+            css-class="card-lead"
+            font-size="19px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            {$name|default('Estudante')}, esse é o último e-mail que mando sobre isso.
+          </mj-text>
+
+          <mj-text css-class="card-body" padding="0px 0px 20px 0px">
+            Você já sabe o que está em jogo: <b>Licenciatura Plena em até 6 meses. Diploma de 3.200 horas. R2 aproveitado por inteiro.</b> Caminho livre pra concurso e pra novas segundas licenciaturas.
+          </mj-text>
+
+          <mj-text css-class="card-body" padding="0px 0px 20px 0px">
+            Tudo isso graças a uma modalidade especial que existe agora, sem garantia de até quando.
+          </mj-text>
+
+          <mj-text
+            css-class="card-body"
+            font-weight="700"
+            color="#EB5A00"
+            padding="0px 0px 20px 0px"
+          >
+            CORRA E APROVEITE ENQUANTO AINDA DÁ PRA FAZER TUDO ISSO EM 6 MESES.
+          </mj-text>
+
+          <mj-text
+            css-class="card-body"
+            font-weight="700"
+            color="#050505"
+            padding="0px 0px 24px 0px"
+          >
+            Aproveite sua última chance de crescer na educação!
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#8D005E"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="18px"
+            line-height="24px"
+            font-weight="700"
+            align="left"
+            width="100%"
+            inner-padding="13px 20px"
+            padding="0px 0px 28px 0px"
+          >
+            MATRICULAR AGORA<br />ENQUANTO AINDA DÁ
+          </mj-button>
+
+          <mj-text
+            css-class="card-title"
+            font-size="24px"
+            line-height="32px"
+            font-weight="700"
+            letter-spacing="-0.02em"
+            color="#8D005E"
+            padding="0px 0px 18px 0px"
+          >
+            Por que decidir hoje
+          </mj-text>
+
+          <mj-text
+            css-class="check-card"
+            padding="0px 0px 9px 0px"
+            font-size="16px"
+            line-height="24px"
+          >
+            <div style="background-color: #FFFFFF; border-radius: 14px; padding: 14px 20px 14px 52px; text-indent: -30px; font-weight: 600; color: #050505;">
+              <span style="color: #F95F00; font-weight: 700">✓</span>&nbsp;&nbsp;&nbsp;Graduação em 6 meses aproveitando seu R2
+            </div>
+          </mj-text>
+
+          <mj-text
+            css-class="check-card"
+            padding="0px 0px 9px 0px"
+            font-size="16px"
+            line-height="24px"
+          >
+            <div style="background-color: #FFFFFF; border-radius: 14px; padding: 14px 20px 14px 52px; text-indent: -30px; font-weight: 600; color: #050505;">
+              <span style="color: #F95F00; font-weight: 700">✓</span>&nbsp;&nbsp;&nbsp;Curso reconhecido pelo MEC
+            </div>
+          </mj-text>
+
+          <mj-text
+            css-class="check-card"
+            padding="0px 0px 26px 0px"
+            font-size="16px"
+            line-height="24px"
+          >
+            <div style="background-color: #FFFFFF; border-radius: 14px; padding: 14px 20px 14px 52px; text-indent: -30px; font-weight: 600; color: #050505;">
+              <span style="color: #F95F00; font-weight: 700">✓</span>&nbsp;&nbsp;&nbsp;Suporte humanizado do início ao diploma
+            </div>
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://mailingredirect.saneducacional.com.br/redirect.php?codlead={$codlead}&amp;produto=04&amp;fornecedor=07&amp;nome_produto=Graduação&amp;curso=000&amp;nome_curso=Graduação"
+            background-color="#8D005E"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="18px"
+            line-height="24px"
+            font-weight="700"
+            align="left"
+            width="100%"
+            inner-padding="18px 20px"
+            padding="0px"
+          >
+            Quero saber mais
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- S4: Respiro preto -->
+      <mj-section background-color="#050505" padding="0px">
+        <mj-column>
+          <mj-spacer height="60px" />
+        </mj-column>
+      </mj-section>
+
+      <!-- S5: Rodapé laranja -->
+      <mj-section background-color="#F95F00" padding="30px 20px 40px 20px">
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="600"
+            color="#FED9CA"
+            padding="0px"
+          >
+            @saneducacional
+          </mj-text>
+
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="20px"
+            font-weight="400"
+            padding="10px 0px 0px 0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #FDCAB1; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
Sequência nova de 6 e-mails sobre **R2 / Formação Pedagógica → Licenciatura Plena (Segunda Licenciatura) em até 6 meses**, implementada a partir dos nodes do Figma.

Arquivos em `src/campanhas/r4-sequencia/sequenciar4-1..6.mjml`.

| # | node | tema |
|---|------|------|
| 1 | `5:354` | Vi seu nome nessa lista |
| 2 | `6:417` | O Brasil vai faltar 235 mil professores |
| 3 | `6:538` | Achei que ia levar anos. Levou 6 meses. |
| 4 | `7:639` | Seu perfil chamou atenção |
| 5 | `10:4` | Multiplique sua qualificação |
| 6 | `10:72` | Última chamada |

## Validação

- `bun run build` sem nenhum warning do MJML.
- Os 6 com `scrollWidth == 375` em viewport de 375px (zero scroll horizontal no mobile).
- Conferência visual em 375px e 700px comparada com o screenshot de cada node.
- 13 CTAs, todos com o mesmo href de rastreio.
- Zero `linear-gradient`, `rgba()`, `position:absolute`, `box-shadow`, `flex`, `grid`, `white-space:nowrap` ou base64.
- 13 imagens, todas no `imghost` — nenhuma URL do Figma ou de host de terceiro.

## Adaptações de design

O design é mobile (393px) e traz bastante coisa que não sobrevive em cliente de e-mail. O que foi feito:

- Degradês de hero **queimados no JPEG** em vez de simulados em CSS, com a borda inferior da imagem casando com a cor da seção seguinte — assim o hero vai edge-to-edge e a emenda some.
- Todo `rgba()` achatado para hex sólido, calculado sobre a cor de fundo real.
- Sombras e glows viram `border: 1px solid` ou nada.
- **Nenhum texto de verdade dentro de imagem** — títulos sobrepostos a fotos saíram para `mj-text` sobre faixa de cor sólida, para o e-mail continuar legível com imagem bloqueada.
- Pílula "CONDIÇÃO ESPECIAL" (e-mail 5) virou badge HTML em vez de ser embutida na foto, pelo mesmo motivo.
- Linha conectora da timeline (e-mail 4) descartada: atravessaria fronteira de `mj-section` e só funcionaria com `position:absolute`. As cores e a copy sustentam a leitura.
- Bolinhas da timeline em CSS, não imagem — Outlook desktop mostra quadrado, o que é degradação menor do que sumir quando o cliente bloqueia imagem.

Textos ficaram literais ao design, incluindo espaço duplo, travessão, emoji e caixa alta.

## Responsividade

Desktop e mobile no mesmo arquivo: a canvas de 602px é o desktop, e `@media only screen and (max-width: 480px)` traz os valores literais do Figma.

Durante a implementação apareceu uma armadilha que vale registrar: **a media query pode falhar em silêncio**. `css-class` numa `mj-text` cai no `<td>`, e o MJML força `font-size:0px` nesse `<td>` — o tamanho real fica inline no `<div>` interno. O mesmo vale para `mj-section` (o filho é `<table>`, não `<tbody>`) e para `mj-button` (vira `<table width:NNN>` + `<a width:MMM>`). Compila 100% limpo e não faz nada.

⚠️ **O padrão inválido `.classe > tbody > tr > td` veio do `sequenciasecretariado1.mjml` e está espalhado pelos e-mails antigos do repo** — vale conferir se as sequências já disparadas estão com o mobile funcionando. Não foi mexido aqui, está fora do escopo deste PR.

## Também incluso

Skill `figma-para-mjml` com o processo documentado e dois scripts de conferência visual (`shot.mjs`, `overflow.mjs`), que usam o Chrome do sistema e não sujam o `package.json`.

## Pontos em aberto

- **Nenhum dos designs tem o gancho "no próximo e-mail vamos…"** que amarra as outras sequências do repo, e só o e-mail 5 tem o "Atenciosamente, Equipe San Educacional" que o `CLAUDE.md` descreve como rodapé fixo. Foi seguido o design ao pé da letra — se a campanha precisa disso, a copy precisa vir do time.
- **Os hrefs usam `produto=04&fornecedor=07&nome_produto=Graduação`**, o par genérico de graduação. Não existe e-mail vizinho desta campanha para copiar. Se o time de tráfego quiser separar o relatório de R2, é trocar em 13 lugares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
