### PR TITLE
feat: adiciona email de pesquisa de satisfação (10% OFF)

### DIFF
--- a/src/campanhas/pesquisa-satisfacao/pesquisa-satisfacao.mjml
+++ b/src/campanhas/pesquisa-satisfacao/pesquisa-satisfacao.mjml
@@ -1,0 +1,270 @@
+<mjml>
+  <mj-head>
+    <mj-title>Ganhe 10% OFF respondendo à pesquisa - San Educacional</mj-title>
+    <mj-font
+      name="Poppins"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800;900&display=swap"
+    />
+    <mj-attributes>
+      <mj-all font-family="Poppins, Arial, sans-serif" />
+      <mj-text font-size="17px" color="#050505" line-height="28px" />
+      <mj-button
+        background-color="#8D005E"
+        color="#ffffff"
+        border-radius="14px"
+        font-weight="700"
+      />
+    </mj-attributes>
+
+    <mj-style>
+      @media only screen and (max-width: 480px) {
+        .headline div {
+          font-size: 34px !important;
+          line-height: 37px !important;
+        }
+        .subtitle div {
+          font-size: 15px !important;
+          line-height: 22px !important;
+        }
+        .card-lead div {
+          font-size: 16px !important;
+          line-height: 24px !important;
+        }
+        .card-body div {
+          font-size: 15px !important;
+          line-height: 24px !important;
+        }
+        .obox-text {
+          font-size: 14px !important;
+          line-height: 21px !important;
+        }
+        .q-title {
+          font-size: 21px !important;
+          line-height: 28px !important;
+        }
+        .btn-wide table {
+          width: 100% !important;
+        }
+        .btn-wide a {
+          display: block !important;
+          width: auto !important;
+          font-size: 16px !important;
+        }
+        .card-pad > table > tbody > tr > td,
+        .head-pad > table > tbody > tr > td {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+
+  <!-- Canvas magenta: é a cor dominante da peça (o design é um cartão #8D005E com
+       cantos arredondados sobre um fundo #910964). No e-mail cada mj-section
+       declara o próprio fundo; a calha lateral magenta no desktop lê como
+       intencional. O hero já foi composto (foto + degradê + logo) num único JPEG
+       cujas últimas linhas são #8D005E, então ele encosta na seção seguinte sem
+       emenda visível. -->
+  <mj-body background-color="#8D005E" width="602px">
+    <mj-wrapper padding="0px">
+      <!-- S1: Hero full-bleed (foto + overlay magenta + logo San Educacional) -->
+      <mj-section background-color="#8D005E" padding="0px">
+        <mj-column>
+          <mj-image
+            src="https://imghost.saneducacional.com.br/H3jKS.jpg"
+            alt="Três pessoas sorrindo em uma reunião de trabalho com notebooks, com a logo San Educacional"
+            width="602px"
+            padding="0px"
+            fluid-on-mobile="true"
+          />
+        </mj-column>
+      </mj-section>
+
+      <!-- S2: Headline + subtítulo + CTA laranja -->
+      <mj-section
+        background-color="#8D005E"
+        padding="6px 28px 44px 28px"
+        css-class="head-pad"
+      >
+        <mj-column>
+          <mj-text
+            align="center"
+            css-class="headline"
+            font-size="40px"
+            line-height="44px"
+            font-weight="700"
+            letter-spacing="-0.02em"
+            color="#FFF8FD"
+            padding="0px 0px 16px 0px"
+          >
+            Ganhe <span style="color: #FFB765">10% OFF</span>
+          </mj-text>
+
+          <mj-text
+            align="center"
+            css-class="subtitle"
+            font-size="17px"
+            line-height="26px"
+            font-weight="400"
+            color="#EBCBE0"
+            padding="0px 20px 28px 20px"
+          >
+            Nos ajude a te oferecer um atendimento ainda melhor.
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://forms.gle/avHgVeoJwuaYQ4AU6"
+            background-color="#F84806"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="17px"
+            line-height="24px"
+            font-weight="700"
+            align="center"
+            width="100%"
+            inner-padding="18px 20px"
+            padding="0px"
+          >
+            👉 Responder à pesquisa (2 min)
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- S3: Card claro -->
+      <mj-section
+        background-color="#FFF8FD"
+        border-radius="22px"
+        padding="28px"
+        css-class="card-pad"
+      >
+        <mj-column width="546px">
+          <mj-text
+            css-class="card-lead"
+            font-size="19px"
+            line-height="28px"
+            font-weight="700"
+            color="#8D005E"
+            padding="0px 0px 20px 0px"
+          >
+            {$name|default('Estudante')}, você demonstrou interesse na Segunda Graduação, mas acabou não seguindo até a matrícula.
+          </mj-text>
+
+          <mj-text css-class="card-body" padding="0px 0px 20px 0px">
+            A gente quer entender melhor o que aconteceu e sua opinião pode ajudar a gente a melhorar. 💜
+          </mj-text>
+
+          <mj-text css-class="card-body" padding="0px 0px 24px 0px">
+            Preparamos uma pesquisa rápida, que leva menos de 2 minutos. Suas respostas vão nos ajudar a oferecer uma experiência cada vez melhor para você e para os próximos alunos da San Educacional.
+          </mj-text>
+
+          <!-- Caixa laranja: badge "10% OFF" + texto. mj-section não aninha, então
+               é um <div> dentro de mj-text; as duas colunas (badge/texto) são uma
+               table inline, único jeito email-safe de manter lado a lado no
+               Outlook e no mobile. -->
+          <mj-text padding="0px 0px 24px 0px">
+            <div style="background-color: #F84806; border-radius: 18px; padding: 22px 20px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                  <td width="76" valign="middle" style="width: 76px;">
+                    <div style="background-color: #FFFFFF; border-radius: 16px; width: 76px; height: 76px;">
+                      <div style="font-size: 25px; line-height: 27px; font-weight: 700; color: #F84806; letter-spacing: -0.75px; text-align: center; padding-top: 16px;">10%</div>
+                      <div style="font-size: 11px; line-height: 14px; font-weight: 700; color: #8D005E; letter-spacing: 0.88px; text-align: center;">OFF</div>
+                    </div>
+                  </td>
+                  <td width="16"></td>
+                  <td valign="middle" class="obox-text" style="font-size: 15px; line-height: 22px; font-weight: 400; color: #FFFFFF;">
+                    E tem um motivo a mais para participar: ao responder, você recebe uma <b>condição especial de desconto no curso que despertou seu interesse.</b>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://forms.gle/avHgVeoJwuaYQ4AU6"
+            background-color="#F84806"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="17px"
+            line-height="24px"
+            font-weight="700"
+            align="center"
+            width="100%"
+            inner-padding="16px 20px"
+            padding="0px 0px 24px 0px"
+          >
+            👉 Responder à pesquisa (2 min)
+          </mj-button>
+
+          <!-- Caixa magenta: "A PERGUNTA PRINCIPAL" + pergunta -->
+          <mj-text padding="0px 0px 24px 0px">
+            <div style="background-color: #BB0185; border-radius: 18px; padding: 22px 18px;">
+              <div style="font-size: 12px; line-height: 17px; font-weight: 700; color: #FFE2B0; letter-spacing: 1.44px; padding-bottom: 12px;">A PERGUNTA PRINCIPAL</div>
+              <div class="q-title" style="font-size: 23px; line-height: 30px; font-weight: 700; color: #FFF8FD; letter-spacing: -0.02em;">Queremos ouvir você de verdade: o que fez você não avançar com a matrícula?</div>
+            </div>
+          </mj-text>
+
+          <mj-text css-class="card-body" padding="0px 0px 24px 0px">
+            Sua resposta é muito importante para nós, {$name|default('Estudante')}. Obrigado por compartilhar sua experiência! 💜
+          </mj-text>
+
+          <mj-button
+            css-class="btn-wide"
+            href="https://forms.gle/avHgVeoJwuaYQ4AU6"
+            background-color="#8D005E"
+            color="#FFFFFF"
+            border-radius="14px"
+            font-size="17px"
+            line-height="24px"
+            font-weight="700"
+            align="center"
+            width="100%"
+            inner-padding="16px 20px"
+            padding="0px"
+          >
+            Responder à pesquisa
+          </mj-button>
+        </mj-column>
+      </mj-section>
+
+      <!-- S4: Rodapé magenta -->
+      <mj-section background-color="#8D005E" padding="30px 20px 40px 20px">
+        <mj-column>
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="19px"
+            font-weight="600"
+            color="#E8C6DD"
+            padding="0px"
+          >
+            0800 145 2300 ·<br />@saneducacional
+          </mj-text>
+
+          <mj-divider
+            border-width="1px"
+            border-color="#AD458A"
+            width="100%"
+            padding="20px 0px 16px 0px"
+          />
+
+          <mj-text
+            align="center"
+            font-size="13px"
+            line-height="19px"
+            font-weight="400"
+            padding="0px"
+          >
+            <a
+              href="{$unsubscribe}"
+              style="color: #DDADCD; text-decoration: underline"
+              >Descadastre-se</a
+            >
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
## O que muda

Novo e-mail traduzido do Figma "Email - Pesquisa de satisfação" para MJML, em `src/campanhas/pesquisa-satisfacao/pesquisa-satisfacao.mjml`.

## Detalhes

- **Hero full-bleed:** foto + degradê magenta + logo San Educacional compostos num único JPEG, com as últimas linhas em `#8D005E` pra emendar sem costura na seção seguinte (hospedado no imghost).
- **Card claro** com lead personalizado, badge "10% OFF", caixa laranja de incentivo e caixa magenta "A PERGUNTA PRINCIPAL".
- **CTAs apontam direto para o Google Form** (`forms.gle/...`), sem redirect de rastreio nem `{$codlead}` — decisão específica desta campanha (é pesquisa de satisfação, não captação de curso).
- Merge vars: `{$name|default('Estudante')}` na saudação e no fechamento, `{$unsubscribe}` no rodapé.
- Responsividade conferida em mobile (375px) e desktop: `bun run build` sem warnings e `overflow.mjs` sem estouros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)