### PR TITLE
docs: torna obrigatório o fluxo subagente + loop de fidelidade (figma-para-mjml)

### DIFF
--- a/.claude/rules/figma-mjml-sempre-subagente.md
+++ b/.claude/rules/figma-mjml-sempre-subagente.md
@@ -1,0 +1,36 @@
+# figma-para-mjml: sempre subagente + loop de fidelidade
+
+Ao usar a skill **`figma-para-mjml`** (implementar um design do Figma como `.mjml`
+deste repo), o fluxo com subagente e a revisão iterativa são **obrigatórios** —
+inclusive para **um único e-mail**, não só para sequências.
+
+## Regra
+
+1. **O orquestrador não escreve o `.mjml`.** Ele extrai o design (Figma MCP),
+   baixa/otimiza e sobe as imagens no `imghost`, e escreve uma **spec** no
+   scratchpad (paleta, escala tipográfica, paddings = literais do design, textos,
+   href de CTA, armadilhas de media query).
+
+2. **Um subagente Implementador escreve o arquivo** a partir da spec. Ele
+   **não abre Figma MCP nem navegador** (economiza contexto e RAM) e compila até
+   `bun run build` sair sem warnings.
+
+3. **O orquestrador revisa visualmente** com Playwright: renderiza o HTML a
+   **393px** e compara **lado a lado** com o print do node do Figma
+   (`get_screenshot`). Também roda `overflow.mjs <html> 375` (scrollWidth == 375).
+
+4. **Itera até ficar fiel.** O orquestrador manda correções concretas ao mesmo
+   subagente via `SendMessage` (deltas objetivos: padding X, largura Y, quebra de
+   linha Z) e refaz o comparativo. Repete até bater com o design. Não declara
+   pronto no primeiro corte — só depois de conferir o comparativo.
+
+5. **Honestidade na entrega:** se sobrar algum delta (métrica de fonte, ±px de
+   altura), aponte explicitamente em vez de dizer "pixel perfect".
+
+## Por quê
+
+Fazer sozinho e declarar pronto sem conferir o render contra o design gera peça
+divergente (paddings largos demais, caixas esticadas, quebras erradas). O loop
+render-a-393 + comparar + corrigir é o que garante fidelidade. Ver também
+`.claude/skills/figma-para-mjml/SKILL.md` (pipeline e armadilha de media query)
+e `.claude/rules/imagens-via-imghost.md`.

--- a/.claude/skills/figma-para-mjml/SKILL.md
+++ b/.claude/skills/figma-para-mjml/SKILL.md
@@ -9,12 +9,18 @@ Traduz um design do Figma para um `.mjml` deste repo. O design **sempre** vem
 com coisas que não existem em cliente de e-mail; metade do trabalho é decidir o
 que vira pixel, o que vira cor sólida e o que é descartado.
 
-Leia junto: `CLAUDE.md` e `.claude/rules/imagens-via-imghost.md`.
+Leia junto: `CLAUDE.md`, `.claude/rules/imagens-via-imghost.md` e
+`.claude/rules/figma-mjml-sempre-subagente.md`.
 
 ## Pipeline com subagentes
 
-Vale a pena quando são vários e-mails de uma sequência. Por e-mail, duas
-equipes-de-um em série:
+**Obrigatório sempre — inclusive para um único e-mail** (ver
+`.claude/rules/figma-mjml-sempre-subagente.md`): o orquestrador extrai o design e
+escreve a spec, um subagente Implementador escreve o `.mjml`, e o orquestrador
+revisa no Playwright (render a 393px vs. print do Figma) e itera via `SendMessage`
+até ficar fiel. Não faça sozinho nem declare pronto sem conferir o comparativo.
+
+Por e-mail, duas equipes-de-um em série:
 
 1. **Lead (Opus)** — navega o Figma, baixa e otimiza os JPEG, sobe no `imghost`,
    escreve uma spec em markdown no scratchpad. **Não escreve o `.mjml`.**


### PR DESCRIPTION
## Resumo

Formaliza como regra o fluxo que a gente validou implementando o e-mail do segundo diploma técnico: ao usar a skill **figma-para-mjml**, o processo com subagente e revisão iterativa passa a ser **obrigatório — inclusive para um único e-mail**.

- Novo arquivo `.claude/rules/figma-mjml-sempre-subagente.md`:
  1. Orquestrador extrai o design (Figma MCP), sobe imagens no `imghost` e escreve a **spec** — não escreve o `.mjml`.
  2. Subagente **Implementador** escreve o arquivo a partir da spec (sem abrir Figma/navegador), build sem warnings.
  3. Orquestrador **revisa no Playwright**: render a **393px** lado a lado com o print do Figma + `overflow.mjs 375`.
  4. **Itera via `SendMessage`** com correções concretas até ficar fiel; nada de declarar pronto no 1º corte.
  5. Entrega honesta sobre deltas residuais.
- Referência da regra adicionada em `.claude/skills/figma-para-mjml/SKILL.md`.

Só documentação/processo — não altera nenhum template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)